### PR TITLE
Add phpunit and mockery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,10 @@
     "require": {
         "php": ">=5.5.9"
     },
+    "require-dev": {
+        "mockery/mockery": "^0.9.7",
+        "phpunit/phpunit": "^4.8 || ^5.4"
+    },
     "autoload": {
         "psr-4": {
             "Laravel\\BrowserKitTesting\\": "src/"


### PR DESCRIPTION
Since we use both `phpunit` and `mockery` in this package we should require it to be installed.