### PR TITLE
Add missing mock for dispatch method

### DIFF
--- a/src/Concerns/MocksApplicationServices.php
+++ b/src/Concerns/MocksApplicationServices.php
@@ -100,7 +100,7 @@ trait MocksApplicationServices
     {
         $mock = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
 
-        $mock->shouldReceive('fire')->andReturnUsing(function ($called) {
+        $mock->shouldReceive('fire', 'dispatch')->andReturnUsing(function ($called) {
             $this->firedEvents[] = $called;
         });
 


### PR DESCRIPTION
Fix this error

```
BadMethodCallException: Method Mockery_0_Illuminate_Contracts_Events_Dispatcher::dispatch() does not exist on this mock object
```

when using `$this->expectsEvents(MyEvent::class)`