### PR TITLE
Allow anything between 3.1 to <4.0 to be installed.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "symfony/css-selector": "3.1.*",
-        "symfony/dom-crawler": "3.1.*"
+        "symfony/css-selector": "~3.1",
+        "symfony/dom-crawler": "~3.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I don't see that this package would have a 6 month release cycle so there no reason to lock it right now.

Signed-off-by: crynobone <crynobone@gmail.com>