### PR TITLE
Adding `getCommandHandler` to events and jobs mock

### DIFF
--- a/src/Concerns/MocksApplicationServices.php
+++ b/src/Concerns/MocksApplicationServices.php
@@ -100,7 +100,7 @@ trait MocksApplicationServices
     {
         $mock = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
 
-        $mock->shouldReceive('fire', 'dispatch')->andReturnUsing(function ($called) {
+        $mock->shouldReceive('fire', 'dispatch', 'getCommandHandler')->andReturnUsing(function ($called) {
             $this->firedEvents[] = $called;
         });
 
@@ -313,7 +313,7 @@ trait MocksApplicationServices
     {
         $mock = Mockery::mock('Illuminate\Contracts\Bus\Dispatcher');
 
-        $mock->shouldReceive('dispatch', 'dispatchNow')->andReturnUsing(function ($dispatched) {
+        $mock->shouldReceive('dispatch', 'dispatchNow', 'getCommandHandler')->andReturnUsing(function ($dispatched) {
             $this->dispatchedJobs[] = $dispatched;
         });
 


### PR DESCRIPTION
We encountered the `BadMethodCallException: Method Mockery_0_Illuminate_Contracts_Bus_Dispatcher::getCommandHandler() does not exist on this mock object` exception when trying to update the company app to Laravel 5.4. 

Adding this method to the mock object on the `MocksApplicationServices` class solved the problem.