### PR TITLE
Fix seeJsonStructure for empty response

### DIFF
--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -351,7 +351,7 @@ trait MakesHttpRequests
             return $this->seeJson();
         }
 
-        if (! $responseData) {
+        if (is_null($responseData)) {
             $responseData = $this->decodeResponseJson();
         }
 


### PR DESCRIPTION
Not a new issue, this fix has already been done in Laravel 5.3

[5.3] Fix seeJsonStructure for empty response #16642
https://github.com/laravel/framework/pull/16642/commits/6ea6e22e77bb66446de18b0ed5b22141a75ba204