### PR TITLE
fix array input multi-file upload test helper

### DIFF
--- a/src/Concerns/InteractsWithPages.php
+++ b/src/Concerns/InteractsWithPages.php
@@ -696,9 +696,7 @@ trait InteractsWithPages
         $names = array_keys($files);
 
         $files = array_map(function (array $file, $name) use ($uploads) {
-            return isset($uploads[$name])
-                        ? $this->getUploadedFileForTesting($file, $uploads, $name)
-                        : $file;
+            return $this->getUploadedFileForTesting($file, $uploads, $name);
         }, $files, $names);
 
         $uploads = array_combine($names, $files);
@@ -746,8 +744,13 @@ trait InteractsWithPages
      */
     protected function getUploadedFileForTesting($file, $uploads, $name)
     {
+        // if file is empty return $file
+        if( $file['error'] == UPLOAD_ERR_NO_FILE ) { return; }
+
+        $originalName = isset( $uploads[$name] ) ? basename($uploads[$name]) :  $file['name'];
+
         return new UploadedFile(
-            $file['tmp_name'], basename($uploads[$name]), $file['type'], $file['size'], $file['error'], true
+            $file['tmp_name'], $originalName, $file['type'], $file['size'], $file['error'], true
         );
     }
 }


### PR DESCRIPTION
this is the pr summited in.
laravel/framework#18031

> copying original comment

Fixed an issue when testing multiple files with a form element like

```html
<input type="file" name="files[]" multiple="multiple"></input>
```

using

```php
// attach file to multiple file element and submit
$this->visit( route( 'page.form' ) )
            ->attach( [$pathToFile] , 'images[]')
            ->press('Submit')
            ->seePageIs( route('page') );
```

An error was thrown because the `Form::getFile()` method returned an array representing the file which never got converted to a `UploadFile`.

The fix converts all files to an instance of `UploadFile` with the test attribute set to true, unless the array returned by `Form::getFile()` has `UPLOAD_ERR_NO_FILE` as its error.

It only fails if there's a validation in the controller like

```php
public function controllerMethod (Request $request)
{
   $this->validate( $request, [
      'files.*' => 'image',
   ] );
}
```

The validation fails because the `test` property of the `UploadFile` instance passed with the request doesn't get set to true.

Therefore since `is_uploaded_file` in `UploadFile::isValid()` returns false, `isValid()` returns a false.

```php
    //UploadFile::isValid()
    /**
     * Returns whether the file was uploaded successfully.
     *
     * @return bool True if the file has been uploaded with HTTP and no error occurred
     */
    public function isValid()
    {
        $isOk = $this->error === UPLOAD_ERR_OK;

        return $this->test ? $isOk : $isOk && is_uploaded_file($this->getPathname());
    }
```
