### PR TITLE
Bootable Testing Traits Support ( Cleaner / Breaking )

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -70,7 +70,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
             $this->refreshApplication();
         }
 
-        $this->setUpTraits();
+        $this->runTraitHooks('setUp');
 
         foreach ($this->afterApplicationCreatedCallbacks as $callback) {
             call_user_func($callback);
@@ -96,28 +96,18 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Boot the testing helper traits.
+     * Run testing helper trait hooks by method prefix.
      *
      * @return void
      */
-    protected function setUpTraits()
+    protected function runTraitHooks(string $prefix)
     {
-        $uses = array_flip(class_uses_recursive(static::class));
+        $class = static::class;
 
-        if (isset($uses[DatabaseMigrations::class])) {
-            $this->runDatabaseMigrations();
-        }
-
-        if (isset($uses[DatabaseTransactions::class])) {
-            $this->beginDatabaseTransaction();
-        }
-
-        if (isset($uses[WithoutMiddleware::class])) {
-            $this->disableMiddlewareForAllTests();
-        }
-
-        if (isset($uses[WithoutEvents::class])) {
-            $this->disableEventsForAllTests();
+        foreach (class_uses_recursive($class) as $trait) {
+            if (method_exists($class, $method = $prefix.class_basename($trait))) {
+                call_user_func([$this, $method]);
+            }
         }
     }
 
@@ -128,6 +118,8 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
      */
     protected function tearDown()
     {
+        $this->runTraitHooks('tearDown');
+
         if ($this->app) {
             foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
                 call_user_func($callback);


### PR DESCRIPTION
Uses the same principle that Eloquent Models use to boot traits. This allows user defined traits to hook into both the `setUp` and `tearDown` methods by defining methods prefixed with `setUp` and `tearDown` respectively.

This is a breaking change that needs to be coordinated with the [sister pull request for Laravel Framework](https://github.com/laravel/framework/pull/18407) and will add a hard requirement for Laravel 5.5

A Non-breaking implementation has been submitted as an alternate here: https://github.com/laravel/browser-kit-testing/pull/19