### PR TITLE
Bootable Testing Traits Support ( Non-breaking )

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -102,6 +102,8 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
      */
     protected function setUpTraits()
     {
+        $this->runTraitHooks('setUp');
+
         $uses = array_flip(class_uses_recursive(static::class));
 
         if (isset($uses[DatabaseMigrations::class])) {
@@ -122,12 +124,30 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Run testing helper trait hooks by method prefix.
+     *
+     * @return void
+     */
+    protected function runTraitHooks(string $prefix)
+    {
+        $class = static::class;
+
+        foreach (class_uses_recursive($class) as $trait) {
+            if (method_exists($class, $method = $prefix.class_basename($trait))) {
+                call_user_func([$this, $method]);
+            }
+        }
+    }
+
+    /**
      * Clean up the testing environment before the next test.
      *
      * @return void
      */
     protected function tearDown()
     {
+        $this->runTraitHooks('tearDown');
+
         if ($this->app) {
             foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
                 call_user_func($callback);


### PR DESCRIPTION
This is an alternate pull request to https://github.com/laravel/browser-kit-testing/pull/18. This is simply an addition of functionality without breaking the current implementation, but is less clean.

Uses the same principle that Eloquent Models use to boot traits. This allows user defined traits to hook into both the `setUp` and `tearDown` methods by defining methods prefixed with `setUp` and `tearDown` respectively.