### PR TITLE
Update MocksApplicationServices.php

### DIFF
--- a/src/Concerns/MocksApplicationServices.php
+++ b/src/Concerns/MocksApplicationServices.php
@@ -202,7 +202,7 @@ trait MocksApplicationServices
             return true;
         });
 
-        $mock->shouldReceive('listen')->andReturnUsing(function ($event, $listener, $priority) {
+        $mock->shouldReceive('listen')->andReturnUsing(function ($event, $listener) {
             //
         });
 


### PR DESCRIPTION
The mock doesn't match the method signature `Illuminate\Events\Dispatcher`, so I have removed the `$priority` argument. I think you mention that you have removed the priorities on events on 5.4 so maybe this is an oversight. Apologies if I'm wrong though.