### PR TITLE
Assert that sequence of strings is seen on the page or not.

### DIFF
--- a/src/Concerns/InteractsWithPages.php
+++ b/src/Concerns/InteractsWithPages.php
@@ -347,6 +347,36 @@ trait InteractsWithPages
     }
 
     /**
+     * Assert that a given sequance of strings is seen on the current text.
+     *
+     * @param  array    $expected
+     * @return $this
+     */
+    public function seeTextInOrder($expected)
+    {
+        if(! is_array($expected)) {
+            $expected = func_get_args();
+        }
+
+        return $this->assertInPage(new HasTextInOrder($expected));
+    }
+
+    /**
+     * Assert that a given sequence is not seen on the current text.
+     *
+     * @param  array    $expected
+     * @return $this
+     */
+    public function dontSeeTextInOrder($expected)
+    {
+        if(! is_array($expected)) {
+            $expected = func_get_args();
+        }
+
+        return $this->assertInPage(new HasTextInOrder($expected), $negate = true);
+    }
+
+    /**
      * Assert that a given string is seen inside an element.
      *
      * @param  string  $element

--- a/src/Constraints/HasTextInOrder.php
+++ b/src/Constraints/HasTextInOrder.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Laravel\BrowserKitTesting\Constraints;
+
+class HasTextInOrder extends PageConstraint {
+    /**
+     * The expected sequance.
+     *
+     * @var array
+     */
+    protected $expected;
+
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  array  $expected
+     * @return void
+     */
+    public function __construct($expected)
+    {
+        $this->expected = $expected;
+    }
+
+    /**
+     * Check if the plain text sequance is found in the given crawler.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler|string  $crawler
+     * @return bool
+     */
+    protected function matches($crawler)
+    {
+        $escapedSequance = array_map(function($text) {
+            return $this->getEscapedPattern($text);
+        }, $this->expected);
+
+        $pattern = join('(?:(.|\n|\r|\s)+?)', $escapedSequance);
+
+        return preg_match("/{$pattern}/i", $this->text($crawler));
+    }
+
+    /**
+     * Returns a string representation of the object.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        $text = join(', ', $this->expected);
+
+        return "the sequance [{$text}]";
+    }
+}


### PR DESCRIPTION
Add the ability to check if sequence of strings is seen in order or not **(useful to check tabular data)**
you can achieve that by using these methods as follows:

```php
$this->seeTextInOrder('first', 'then', 'last');
$this->seeTextInOrder(['first', 'then', 'last']);
```
Or if you don't want to see them in order:

```php
$this->dontSeeTextInOrder('last', 'then', 'first');
$this->dontSeeTextInOrder(['last', 'then', 'first']);
```

And of course you can chain them:

```php
$this->seeRouteIs('index')
     ->seeText('first')
     ->seeText('second')
     ->seeText('third')
     ->seeTextInOrder('first', 'second', 'third')
     ->dontSeeTextInOrder('third', 'first', 'second');
```