### PR TITLE
Support for PHPUnit 6.x

### DIFF
--- a/src/Concerns/InteractsWithPages.php
+++ b/src/Concerns/InteractsWithPages.php
@@ -18,7 +18,7 @@ use Laravel\BrowserKitTesting\Constraints\IsSelected;
 use Laravel\BrowserKitTesting\Constraints\HasInElement;
 use Laravel\BrowserKitTesting\Constraints\PageConstraint;
 use Laravel\BrowserKitTesting\Constraints\ReversePageConstraint;
-use PHPUnit_Framework_ExpectationFailedException as PHPUnitException;
+use PHPUnit\Framework\ExpectationFailedException as PHPUnitException;
 
 trait InteractsWithPages
 {

--- a/src/Concerns/InteractsWithSession.php
+++ b/src/Concerns/InteractsWithSession.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\BrowserKitTesting\Concerns;
 
-use PHPUnit_Framework_Assert as PHPUnit;
+use PHPUnit\Framework\Assert as PHPUnit;
 
 trait InteractsWithSession
 {

--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -8,8 +8,8 @@ use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Contracts\View\View;
-use PHPUnit_Framework_Assert as PHPUnit;
-use PHPUnit_Framework_ExpectationFailedException;
+use PHPUnit\Framework\Assert as PHPUnit;
+use PHPUnit\Framework\ExpectationFailedException;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 
@@ -322,7 +322,7 @@ trait MakesHttpRequests
 
         try {
             return $this->seeJsonEquals($data);
-        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+        } catch (ExpectationFailedException $e) {
             return $this->seeJsonContains($data, $negate);
         }
     }

--- a/src/Constraints/FormFieldConstraint.php
+++ b/src/Constraints/FormFieldConstraint.php
@@ -48,7 +48,7 @@ abstract class FormFieldConstraint extends PageConstraint
      * @param  \Symfony\Component\DomCrawler\Crawler  $crawler
      * @return \Symfony\Component\DomCrawler\Crawler
      *
-     * @throws \PHPUnit_Framework_ExpectationFailedException
+     * @throws \PHPUnit\Framework\ExpectationFailedException
      */
     protected function field(Crawler $crawler)
     {

--- a/src/Constraints/HasValue.php
+++ b/src/Constraints/HasValue.php
@@ -35,7 +35,7 @@ class HasValue extends FormFieldConstraint
      * @param  \Symfony\Component\DomCrawler\Crawler  $crawler
      * @return string
      *
-     * @throws \PHPUnit_Framework_ExpectationFailedException
+     * @throws \PHPUnit\Framework\ExpectationFailedException
      */
     public function getInputOrTextAreaValue(Crawler $crawler)
     {

--- a/src/Constraints/IsSelected.php
+++ b/src/Constraints/IsSelected.php
@@ -36,7 +36,7 @@ class IsSelected extends FormFieldConstraint
      * @param  \Symfony\Component\DomCrawler\Crawler  $crawler
      * @return array
      *
-     * @throws \PHPUnit_Framework_ExpectationFailedException
+     * @throws \PHPUnit\Framework\ExpectationFailedException
      */
     public function getSelectedValue(Crawler $crawler)
     {

--- a/src/Constraints/PageConstraint.php
+++ b/src/Constraints/PageConstraint.php
@@ -2,12 +2,12 @@
 
 namespace Laravel\BrowserKitTesting\Constraints;
 
-use PHPUnit_Framework_Constraint;
 use Symfony\Component\DomCrawler\Crawler;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\ExpectationFailedException;
 use SebastianBergmann\Comparator\ComparisonFailure;
-use PHPUnit_Framework_ExpectationFailedException as FailedExpection;
 
-abstract class PageConstraint extends PHPUnit_Framework_Constraint
+abstract class PageConstraint extends Constraint
 {
     /**
      * Make sure we obtain the HTML from the crawler or the response.
@@ -66,7 +66,7 @@ abstract class PageConstraint extends PHPUnit_Framework_Constraint
      * @param  \SebastianBergmann\Comparator\ComparisonFailure|null  $comparisonFailure
      * @return void
      *
-     * @throws \PHPUnit_Framework_ExpectationFailedException
+     * @throws \PHPUnit\Framework\ExpectationFailedException
      */
     protected function fail($crawler, $description, ComparisonFailure $comparisonFailure = null)
     {
@@ -87,7 +87,7 @@ abstract class PageConstraint extends PHPUnit_Framework_Constraint
             $failureDescription .= '. The response is empty.';
         }
 
-        throw new FailedExpection($failureDescription, $comparisonFailure);
+        throw new ExpectationFailedException($failureDescription, $comparisonFailure);
     }
 
     /**

--- a/src/HttpException.php
+++ b/src/HttpException.php
@@ -2,9 +2,9 @@
 
 namespace Laravel\BrowserKitTesting;
 
-use PHPUnit_Framework_ExpectationFailedException;
+use PHPUnit\Framework\ExpectationFailedException;
 
-class HttpException extends PHPUnit_Framework_ExpectationFailedException
+class HttpException extends ExpectationFailedException
 {
     //
 }


### PR DESCRIPTION
Related issue: https://github.com/laravel/browser-kit-testing/issues/13

PHPUnit 5.x is not supported anymore with those changes so it should be tagged as major release if accepted.