### PR TITLE
Bump version for PHPUnit 6.x release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "2.0-dev"
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Should we as well require `"phpunit/phpunit": "~6.0"`?