### PR TITLE
Add PHPUnit as required dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require": {
         "php": ">=5.5.9",
         "symfony/css-selector": "~3.1",
-        "symfony/dom-crawler": "~3.1"
+        "symfony/dom-crawler": "~3.1",
+        "phpunit/phpunit": "~6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
To prevent people from installing browser-kit-testing 2.x with PHPUnit 5.7.

See https://github.com/laravel/browser-kit-testing/issues/13