### PR TITLE
Add correct return type to seeInSession

### DIFF
--- a/src/Concerns/InteractsWithSession.php
+++ b/src/Concerns/InteractsWithSession.php
@@ -63,7 +63,7 @@ trait InteractsWithSession
      *
      * @param  string|array  $key
      * @param  mixed  $value
-     * @return void
+     * @return $this
      */
     public function seeInSession($key, $value = null)
     {


### PR DESCRIPTION
seeInSession was marked as returning void when it always returns $this.