### PR TITLE
Reset error_reporting after makeRequest()

### DIFF
--- a/src/Concerns/InteractsWithPages.php
+++ b/src/Concerns/InteractsWithPages.php
@@ -85,6 +85,8 @@ trait InteractsWithPages
      */
     protected function makeRequest($method, $uri, $parameters = [], $cookies = [], $files = [])
     {
+        $level = error_reporting();
+        
         $uri = $this->prepareUrlForRequest($uri);
 
         $this->call($method, $uri, $parameters, $cookies, $files);
@@ -94,6 +96,8 @@ trait InteractsWithPages
         $this->currentUri = $this->app->make('request')->fullUrl();
 
         $this->crawler = new Crawler($this->response->getContent(), $this->currentUri);
+        
+        error_reporting($level);
 
         return $this;
     }


### PR DESCRIPTION
Some packages (i'm looking at you [ytake/Laravel.Smarty](https://github.com/ytake/Laravel.Smarty)) set their own `error_reporting` level, which in most cases in a production or dev environment is fine, because after each request the `error_reporting` level is obviously reset to the Laravel default.

In a testing environment, because the `app` persists across requests, if the `error_reporting` level has been changed, all subsequent requests have the new `error_reporting` level which can cause undesired side-affect...like tests passing, but code failing in production (which we found out to our cost).

For example, [ytake/Laravel.Smarty](https://github.com/ytake/Laravel.Smarty) by default sets the `error_reporting` level to `E_ALL & ~E_NOTICE`, so all subsequent requests in our integration tests had that level set, which failed to pickup an undefined variable in one our controllers.

This PR I feel makes the integration tests behave more like the app would in the browser.