### PR TITLE
Fixes InteractsWithExceptionHandling Namespacing

### DIFF
--- a/src/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Concerns/InteractsWithExceptionHandling.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Foundation\Testing\Concerns;
+namespace Laravel\BrowserKitTesting\Concerns;
 
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;


### PR DESCRIPTION
Not following the PSR autoload namespacing used by all the other files. 
Causes error "Trait 'Laravel\BrowserKitTesting\Concerns\InteractsWithExceptionHandling'"