### PR TITLE
Add assertions to avoid the risky tests label in phpunit 6

### DIFF
--- a/src/Concerns/MocksApplicationServices.php
+++ b/src/Concerns/MocksApplicationServices.php
@@ -56,11 +56,10 @@ trait MocksApplicationServices
         $this->beforeApplicationDestroyed(function () use ($events) {
             $fired = $this->getFiredEvents($events);
 
-            if ($eventsNotFired = array_diff($events, $fired)) {
-                throw new Exception(
-                    'These expected events were not fired: ['.implode(', ', $eventsNotFired).']'
-                );
-            }
+            $this->assertEmpty(
+                $eventsNotFired = array_diff($events, $fired),
+                'These expected events were not fired: ['.implode(', ', $eventsNotFired).']'
+            );
         });
 
         return $this;
@@ -81,11 +80,10 @@ trait MocksApplicationServices
         $this->withoutEvents();
 
         $this->beforeApplicationDestroyed(function () use ($events) {
-            if ($fired = $this->getFiredEvents($events)) {
-                throw new Exception(
-                    'These unexpected events were fired: ['.implode(', ', $fired).']'
-                );
-            }
+            $this->assertEmpty(
+                $fired = $this->getFiredEvents($events),
+                'These unexpected events were fired: ['.implode(', ', $fired).']'
+            );
         });
 
         return $this;
@@ -269,11 +267,10 @@ trait MocksApplicationServices
         $this->beforeApplicationDestroyed(function () use ($jobs) {
             $dispatched = $this->getDispatchedJobs($jobs);
 
-            if ($jobsNotDispatched = array_diff($jobs, $dispatched)) {
-                throw new Exception(
-                    'These expected jobs were not dispatched: ['.implode(', ', $jobsNotDispatched).']'
-                );
-            }
+            $this->assertEmpty(
+                $jobsNotDispatched = array_diff($jobs, $dispatched),
+                'These expected jobs were not dispatched: ['.implode(', ', $jobsNotDispatched).']'
+            );
         });
 
         return $this;
@@ -294,11 +291,10 @@ trait MocksApplicationServices
         $this->withoutJobs();
 
         $this->beforeApplicationDestroyed(function () use ($jobs) {
-            if ($dispatched = $this->getDispatchedJobs($jobs)) {
-                throw new Exception(
-                    'These unexpected jobs were dispatched: ['.implode(', ', $dispatched).']'
-                );
-            }
+            $this->assertEmpty(
+                $dispatched = $this->getDispatchedJobs($jobs),
+                'These unexpected jobs were dispatched: ['.implode(', ', $dispatched).']'
+            );
         });
 
         return $this;
@@ -411,9 +407,7 @@ trait MocksApplicationServices
                 }
             }
 
-            throw new Exception(
-                'The following expected notification were not dispatched: ['.$notification.']'
-            );
+            $this->fail('The following expected notification were not dispatched: ['.$notification.']');
         });
 
         return $this;


### PR DESCRIPTION
Using phpunit 6 and browser-kit-testing >= 2.0.1 if a test only uses the expects methods provided by MocksApplicationServices the test will be marked as risky because it not perform any assertions.