### PR TITLE
Change a few concerns to use framework versions

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -11,17 +11,22 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithConsole;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithAuthentication;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithExceptionHandling;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithSession;
 
 abstract class TestCase extends BaseTestCase
 {
     use Concerns\InteractsWithContainer,
         Concerns\MakesHttpRequests,
         Concerns\ImpersonatesUsers,
-        Concerns\InteractsWithAuthentication,
-        Concerns\InteractsWithConsole,
-        Concerns\InteractsWithDatabase,
-        Concerns\InteractsWithExceptionHandling,
-        Concerns\InteractsWithSession,
+        InteractsWithAuthentication,
+        InteractsWithConsole,
+        InteractsWithDatabase,
+        InteractsWithExceptionHandling,
+        InteractsWithSession,
         Concerns\MocksApplicationServices;
 
     /**


### PR DESCRIPTION
Currently we have our own copy of

    InteractsWithDatabase
    InteractsWithConsole
    InteractsWithAuthentication
    InteractsWithSession
    InteractsWithExceptionHandling

That are the same as the core versions (but vary between 5.3, 5.4 and 5.5 (for example in 5.5 the functions for InteractsWithDatabase are different then the ones in this repo)). We should use the core versions for these rather then manually using our own.

Unless I am missing something?