### PR TITLE
You can only write to input and textarea elements

### DIFF
--- a/src/Concerns/InteractsWithPages.php
+++ b/src/Concerns/InteractsWithPages.php
@@ -519,7 +519,23 @@ trait InteractsWithPages
      */
     protected function type($text, $element)
     {
-        return $this->storeInput($element, $text);
+        $field = $this->filterByNameOrId($element, ['input','textarea']);
+
+        if (! count($field)) {
+            throw new PHPUnitException(
+                sprintf(
+                    "%s\n\n\n%s",
+                    $this->crawler()->html(),
+                    "Dont exists input,textarea with the name or ID [name]. Please check the content above."
+                )
+            );
+        }
+
+        $element = str_replace(['#', '[]'], '', $element);
+
+        $this->inputs[$element] = $text;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
On `Laravel\BrowserKitTesting\Concerns\InteractsWithPages` trait, the `type`
method allows type on any elements (buttons, links, images, etc)

Example on a Laravel Project:

Routes (web.php)
```php
<?php

use App\User;

Route::get('users', function () {
    $users = User::all();
    return view('list-user', compact('users'));
});

Route::post('searcher', function () {
    $users = User::where('name', request()->name)->get();
    return view('list-user', compact('users'));
});
```

View (list-users.blade.php)
```php
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <title>Searcher</title>
</head>
<body>
    <nav class="navbar" id="navbar">
        <form action="{{ url('searcher') }}" method="post" class="form-inline">
            {{ csrf_field() }}
            <input type="search" class="form-control" placeholde="Name" aria-label="Search">
            <button class="btn" type="submit" name="name">Search</button>
        </form>
    </nav>
    @foreach($users as $user)
        <div class="card">
            <div class="card-body">
                <h5 class="card-title">{{ $user->name }}</h5>
                <a href="#">Edit</a><a href="#">Delete</a>
            </div>
        </div>
    @endforeach
</body>
</html>
```

Unit Test (SearcherTest.php)
```php
<?php

namespace Tests\Feature;

use App\User;
use Illuminate\Foundation\Testing\RefreshDatabase;
use Laravel\BrowserKitTesting\Concerns\type;
use Tests\TestCase;

class SearcherTest extends TestCase
{
    public function use_searcher()
    {
        // HAVING ONLY TWO USERS IN DATABASES...
        factory(User::class)->create(['name' => 'Taylor']);
        factory(User::class)->create(['name' => 'Erick']);

        $this->visit('users')
            ->see('Erick')
            ->see('Taylor');

        $this->type('Taylor', 'name')
            ->press('Search')
            ->dontSee('Erick')
            ->see('Taylor');
    }
}

```

Unit Test are passing because button of searcher have `name` name. But on the browser,
the searcher aren't' working because input of searcher haven't `name` name