### PR TITLE
Type Method write on input or textarea elements

### DIFF
--- a/src/Concerns/InteractsWithPages.php
+++ b/src/Concerns/InteractsWithPages.php
@@ -519,7 +519,23 @@ trait InteractsWithPages
      */
     protected function type($text, $element)
     {
-        return $this->storeInput($element, $text);
+        $field = $this->filterByNameOrId($element, ['input','textarea']);
+
+        if (! count($field)) {
+            throw new PHPUnitException(
+                sprintf(
+                    "%s\n\n\n%s",
+                    $this->crawler()->html(),
+                    "Dont exists input,textarea with the name or ID [name]. Please check the content above."
+                )
+            );
+        }
+
+        $element = str_replace(['#', '[]'], '', $element);
+
+        $this->inputs[$element] = $text;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
With this change, the `type` method of `Laravel\BrowserKitTesting\Concerns\InteractsWithPages` trait will allow write on input or textarea elements. On any other elements(button, span, strong, etc), it's will throw the exception `PHPUnit\Framework\ExpectationFailedException`

**Reason it does not break any existing feature:**
`type` method verify if exist input or textarea elements that it having the passed name by parameter. After it's save the data on $input attribute.