### PR TITLE
Assert response is Symfony RedirectResponse in assertRedirectedTo

### DIFF
--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -819,7 +819,7 @@ trait MakesHttpRequests
      */
     public function assertRedirectedTo($uri, $with = [])
     {
-        PHPUnit::assertInstanceOf('Illuminate\Http\RedirectResponse', $this->response);
+        PHPUnit::assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $this->response);
 
         PHPUnit::assertEquals($this->app['url']->to($uri), $this->response->headers->get('Location'));
 


### PR DESCRIPTION
This is more of a *nice to have*, rather than an issue.

Currently, `assertRedirectedTo` checks that the response is an instance of `Illuminate\Http\RedirectResponse`. This causes tests to fail when returning instances of its parent class, `Symfony\Component\HttpFoundation\RedirectResponse`.

This PR changes the assertion to check that the response is an instance of `Symfony\Component\HttpFoundation\RedirectResponse` to allow for instances of either object to be returned.