### PR TITLE
Add $unserialize param to fix breaking change of 5.6.30

### DIFF
--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -505,9 +505,10 @@ trait MakesHttpRequests
      * @param  string  $cookieName
      * @param  mixed  $value
      * @param  bool  $encrypted
+     * @param  bool  $unserialize
      * @return $this
      */
-    protected function seeCookie($cookieName, $value = null, $encrypted = true)
+    protected function seeCookie($cookieName, $value = null, $encrypted = true, $unserialize = true)
     {
         $headers = $this->response->headers;
 
@@ -529,7 +530,7 @@ trait MakesHttpRequests
         $cookieValue = $cookie->getValue();
 
         $actual = $encrypted
-            ? $this->app['encrypter']->decrypt($cookieValue) : $cookieValue;
+            ? $this->app['encrypter']->decrypt($cookieValue, $unserialize) : $cookieValue;
 
         $this->assertEquals(
             $actual, $value,


### PR DESCRIPTION
The breaking change of 5.6.30 (not serialize cookie values by default) broke the `seeCookie()` method of Browser Kit Testing. This PR fixes this.

Developers with app below 5.6.30 don't need to do anything. Developers with app 5.6.30+ need to update their tests like so:

```php
// true is for encrypted (default value)
// false is for not unserializing (this fixes the test)
$this->seeCookie('name', 'value', true, false);
```