### PR TITLE
[5.7.4] Update MocksApplicationServices to expect dispatch instead of fire.

### DIFF
--- a/src/Concerns/MocksApplicationServices.php
+++ b/src/Concerns/MocksApplicationServices.php
@@ -190,7 +190,7 @@ trait MocksApplicationServices
     {
         $mock = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
 
-        $mock->shouldReceive('fire')->andReturnUsing(function ($called) {
+        $mock->shouldReceive('dispatch')->andReturnUsing(function ($called) {
             $this->firedModelEvents[] = $called;
         });
 


### PR DESCRIPTION
Change expect fire to expect dispatch.

I'm fairly certain this change is needed to stay compatible with this change in Laravel framework release 5.7.4:
https://github.com/laravel/framework/commit/b298de2cf10a9828162d502a1f6b92089aadee18