### PR TITLE
Make it possible to disable a specific middleware

### DIFF
--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -41,11 +41,26 @@ trait MakesHttpRequests
     /**
      * Disable middleware for the test.
      *
+     * @param null $middleware
+     *
      * @return $this
      */
-    public function withoutMiddleware()
+    public function withoutMiddleware($middleware = null)
     {
-        $this->app->instance('middleware.disable', true);
+        if (is_null($middleware)) {
+            $this->app->instance('middleware.disable', true);
+
+            return $this;
+        }
+
+        foreach ((array) $middleware as $abstract) {
+            $this->app->instance($abstract, new class {
+                public function handle($request, $next)
+                {
+                    return $next($request);
+                }
+            });
+        }
 
         return $this;
     }


### PR DESCRIPTION
This is just a copy paste from 

`Illuminate\Foundation\Testing\Concerns\MakesHttpRequests::withoutMiddleware`;
