### PR TITLE
[4.0] Require Mockery and cleanup composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,11 @@
     ],
     "require": {
         "php": ">=7.1.3",
+        "illuminate/support": "^5.6",
+        "mockery/mockery": "^1.0",
+        "phpunit/phpunit": "^7.0",
         "symfony/css-selector": "~4.0",
-        "symfony/dom-crawler": "~4.0",
-        "phpunit/phpunit": "~7.0",
-        "illuminate/support": "^5.6"
+        "symfony/dom-crawler": "~4.0"
     },
     "autoload": {
         "psr-4": {
@@ -30,6 +31,11 @@
         "branch-alias": {
             "dev-master": "4.0-dev"
         }
+    },
+    "config": {
+        "preferred-install": "dist",
+        "sort-packages": true,
+        "optimize-autoloader": true
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
Mockery was absent even though it's a hard dependency of the library. Also cleaned up the compsoser.json file a bit with config settings from other Laravel libraries.

See https://github.com/laravel/browser-kit-testing/issues/41