### PR TITLE
Complete coverage on InteractsWithAuthentication

### DIFF
--- a/tests/Unit/InteractsWithAuthenticationTest.php
+++ b/tests/Unit/InteractsWithAuthenticationTest.php
@@ -102,4 +102,42 @@ class InteractsWithAuthenticationTest extends TestCase
 
         $this->seeIsAuthenticatedAs($user);
     }
+
+    /**
+     * @test
+     */
+    public function can_assert_if_someone_is_authenticated()
+    {
+        $this->app = new class {
+            public $check;
+            public function make() { return $this; }
+            public function guard() { return $this; }
+            public function check() { return $this->check; }
+        };
+
+        $this->app->check = true;
+        $this->assertTrue($this->isAuthenticated());
+
+        $this->app->check = false;
+        $this->assertFalse($this->isAuthenticated());
+    }
+
+    /**
+     * @test
+     */
+    public function assert_if_someone_is_authenticated()
+    {
+        $this->app = new class {
+            public $check;
+            public function make() { return $this; }
+            public function guard() { return $this; }
+            public function check() { return $this->check; }
+        };
+
+        $this->app->check = true;
+        $this->seeIsAuthenticated();
+
+        $this->app->check = false;
+        $this->dontSeeIsAuthenticated();
+    }
 }

--- a/tests/Unit/InteractsWithAuthenticationTest.php
+++ b/tests/Unit/InteractsWithAuthenticationTest.php
@@ -60,4 +60,29 @@ class InteractsWithAuthenticationTest extends TestCase
             "Case 03" => [true, false]
         ];
     }
+
+    /**
+     * @test
+     */
+    public function assert_if_credentials_are_valid_or_invalid()
+    {
+        $this->app = new class {
+            public $retrieveByCredentials;
+            public $validateCredentials;
+            public function make() { return $this; }
+            public function guard() { return $this; }
+            public function getProvider() { return $this; }
+            public function retrieveByCredentials() { return $this->retrieveByCredentials; }
+            public function validateCredentials() { return $this->validateCredentials; }
+        };
+        $this->app->retrieveByCredentials = true;
+        $this->app->validateCredentials = true;
+        $credentials = [
+            'email' => 'john.doe@testing.com',
+            'password' => 'secret'
+        ];
+        $this->seeCredentials($credentials);
+        $this->app->retrieveByCredentials = false;
+        $this->dontSeeCredentials($credentials);
+    }
 }

--- a/tests/Unit/InteractsWithAuthenticationTest.php
+++ b/tests/Unit/InteractsWithAuthenticationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Laravel\BrowserKitTesting\Tests\Unit;
+
+use Laravel\BrowserKitTesting\Concerns\InteractsWithAuthentication;
+use Laravel\BrowserKitTesting\Tests\TestCase;
+
+class InteractsWithAuthenticationTest extends TestCase
+{
+    use InteractsWithAuthentication;
+
+    /**
+     * @test
+     */
+    public function hasCredentials_return_true_if_the_credentials_are_valid()
+    {
+        $this->app = new class {
+            public function make() { return $this; }
+            public function guard() { return $this; }
+            public function getProvider() { return $this; }
+            public function retrieveByCredentials() { return true; }
+            public function validateCredentials() { return true; }
+        };
+        $credentials = [
+            'email' => 'john.doe@testing.com',
+            'password' => 'secret'
+        ];
+        $this->assertTrue($this->hasCredentials($credentials));
+    }
+
+    /**
+     * @test
+     * @dataProvider DataHasCredentials
+     */
+    public function hasCredentials_return_false_if_the_credentials_arent_valid($validateCredentials, $retrieveByCredentials)
+    {
+        $this->app = new class {
+            public $retrieveByCredentials;
+            public $validateCredentials;
+            public function make() { return $this; }
+            public function guard() { return $this; }
+            public function getProvider() { return $this; }
+            public function retrieveByCredentials() { return $this->retrieveByCredentials; }
+            public function validateCredentials() { return $this->validateCredentials; }
+        };
+        $this->app->retrieveByCredentials = $retrieveByCredentials;
+        $this->app->validateCredentials = $validateCredentials;
+        $credentials = [
+            'email' => 'john.doe@testing.com',
+            'password' => 'secret'
+        ];
+        $this->assertFalse($this->hasCredentials($credentials));
+    }
+
+    public function DataHasCredentials()
+    {
+        return [
+            "Case 01" => [false, true],
+            "Case 02" => [false, false],
+            "Case 03" => [true, false]
+        ];
+    }
+}

--- a/tests/Unit/MakesHttpRequestsTest.php
+++ b/tests/Unit/MakesHttpRequestsTest.php
@@ -208,7 +208,7 @@ class MakesHttpRequestsTest extends TestCase
 
         $this->assertInstanceOf(\Symfony\Component\DomCrawler\Form::class, $this->getForm('Search'));
     }
-    
+
     /**
      * @test
      */


### PR DESCRIPTION
I added unit tests for the trait InteractsWithAuthentication (completed coverage).

Covered methods: `seeIsAuthenticated`, `dontSeeIsAuthenticated`,
`isAuthenticated`, `seeIsAuthenticatedAs`, `seeCredentials`,
`dontSeeCredentials`, `hasCredentials`

Change to be committed:
    new file:      tests/Unit/InteractsWithAuthenticationTest.php
    modified:      tests/Unit/MakesHttpRequestsTest.php