### PR TITLE
[5.0] PHPUnit 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.phar
 composer.lock
 .DS_Store
 Thumbs.db
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,16 @@ php:
   - 7.2
   - 7.3
 
+matrix:
+  fast_finish: true
+  include:
+    - env: PHPUNIT=^7.0
+    - env: PHPUNIT=^8.0
+
 sudo: false
 
-install: travis_retry composer install --no-interaction --prefer-dist --no-suggest
+install:
+  - travis_retry composer install --no-interaction --prefer-dist --no-suggest
+  - travis_retry composer require phpunit/phpunit:$PHPUNIT --update-with-dependencies
 
 script: vendor/bin/phpunit --verbose

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=7.1.3",
         "illuminate/support": "^5.6",
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^7.0|^8.0",
         "symfony/css-selector": "~4.0",
         "symfony/dom-crawler": "~4.0"
     },

--- a/src/Concerns/InteractsWithPages.php
+++ b/src/Concerns/InteractsWithPages.php
@@ -3,6 +3,7 @@
 namespace Laravel\BrowserKitTesting\Concerns;
 
 use Closure;
+use Exception;
 use InvalidArgumentException;
 use Illuminate\Http\UploadedFile;
 use Symfony\Component\DomCrawler\Form;
@@ -214,10 +215,11 @@ trait InteractsWithPages
         } catch (PHPUnitException $e) {
             $message = $message ?: "A request to [{$uri}] failed. Received status code [{$status}].";
 
-            $responseException = isset($this->response->exception)
-                    ? $this->response->exception : null;
+            if (isset($this->response->exception)) {
+                throw new HttpException($message, null, $this->response->exception);
+            }
 
-            throw new HttpException($message, null, $responseException);
+            throw new HttpException($message);
         }
     }
 

--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -420,6 +420,8 @@ trait MakesHttpRequests
      *
      * @param  array  $data
      * @return $this
+     *
+     * @deprecated This method will be removed in 5.0
      */
     protected function seeJsonSubset(array $data)
     {

--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -372,7 +372,7 @@ trait MakesHttpRequests
 
         foreach ($structure as $key => $value) {
             if (is_array($value) && $key === '*') {
-                $this->assertInternalType('array', $responseData);
+                $this->assertIsArray($responseData);
 
                 foreach ($responseData as $responseDataItem) {
                     $this->seeJsonStructure($structure['*'], $responseDataItem);

--- a/src/HttpException.php
+++ b/src/HttpException.php
@@ -2,9 +2,9 @@
 
 namespace Laravel\BrowserKitTesting;
 
-use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\AssertionFailedError;
 
-class HttpException extends ExpectationFailedException
+class HttpException extends AssertionFailedError
 {
     //
 }

--- a/tests/Unit/MakesHttpRequestsTest.php
+++ b/tests/Unit/MakesHttpRequestsTest.php
@@ -3,7 +3,9 @@
 namespace Laravel\BrowserKitTesting\Tests\Unit;
 
 use InvalidArgumentException;
+use Laravel\BrowserKitTesting\HttpException;
 use Laravel\BrowserKitTesting\Tests\TestCase;
+use PHPUnit\Framework\ExpectationFailedException;
 use Laravel\BrowserKitTesting\Concerns\MakesHttpRequests;
 
 class MakesHttpRequestsTest extends TestCase
@@ -153,11 +155,12 @@ class MakesHttpRequestsTest extends TestCase
 
     /**
      * @test
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Nothing matched the filter [name] CSS query provided for [].
      */
     public function when_input_dont_exist_storeInput_throw_exception()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Nothing matched the filter [name] CSS query provided for [].');
+
         $html = '<html>
             <body>
                 <form action="https://localhost" method="post">
@@ -192,11 +195,12 @@ class MakesHttpRequestsTest extends TestCase
 
     /**
      * @test
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Could not find a form that has submit button [Search].
      */
     public function when_exists_button_getForm_method_throw_exception()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not find a form that has submit button [Search].');
+
         $html = '<html>
             <body>
                 <form action="http://localhost" method="POST">
@@ -387,11 +391,12 @@ class MakesHttpRequestsTest extends TestCase
 
     /**
      * @test
-     * @expectedException \Laravel\BrowserKitTesting\HttpException
-     * @expectedExceptionMessage A request to [http://localhost/login] failed. Received status code [404].
      */
-    public function assertPageLoaded_throw_exception_when_the_page_wasnt_loaded_correctly()
+    public function assertPageLoaded_throw_exception_when_the_page_was_not_loaded_correctly()
     {
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('A request to [http://localhost/login] failed. Received status code [404].');
+
         $this->app = null;
         $this->response = new class {
             public function getStatusCode() { return 404; }
@@ -425,11 +430,12 @@ class MakesHttpRequestsTest extends TestCase
 
     /**
      * @test
-     * @expectedException \PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage Expected status code 200, got 404.
      */
-    public function assertResponseOk_throw_exception_when_the_status_page_isnt_200()
+    public function assertResponseOk_throw_exception_when_the_status_page_is_not_200()
     {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Expected status code 200, got 404.');
+
         $this->response = new class {
             public function getStatusCode() { return 404; }
             public function isOK() { return false; }
@@ -450,11 +456,12 @@ class MakesHttpRequestsTest extends TestCase
 
     /**
      * @test
-     * @expectedException \PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage Expected status code 404, got 200.
      */
-    public function assertResponseStatus_throw_exception_when_the_response_status_isnt_equal_to_passed_by_parameter()
+    public function assertResponseStatus_throw_exception_when_the_response_status_is_not_equal_to_passed_by_parameter()
     {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Expected status code 404, got 200.');
+
         $this->response = new class {
             public function getStatusCode() { return 200; }
         };


### PR DESCRIPTION
This PR provides compatibility for PHPUnit 8. I managed to do this in a compatible way with PHPUnit 7.0 so there's no major version release needed, only a minor one. I've also updated Travis to test both against PHPUnit 7 and 8.

The only thing that really changed is that `Laravel\BrowserKitTesting\HttpException` isn't an instance of `PHPUnit\Framework\ ExpectationFailedException` anymore. But I don't know if this change warrants a new major version release.