### PR TITLE
[4.0] Remove unnecessary .gitignore lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,2 @@
-.idea/
 /vendor
-/.env
-composer.phar
 composer.lock
-.DS_Store
-Thumbs.db


### PR DESCRIPTION
These belong in a global gitignore or a simply not used in the project.