### PR TITLE
[4.0] Prevent installs of PHPUnit 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,9 @@
 language: php
 
-matrix:
-  fast_finish: true
-  include:
-    - php: 7.1
-      env: PHPUNIT=^7.0
-    - php: 7.2
-      env: PHPUNIT=^7.0
-    - php: 7.2
-      env: PHPUNIT=^8.0
-    - php: 7.3
-      env: PHPUNIT=^7.0
-    - php: 7.3
-      env: PHPUNIT=^8.0
+php:
+  - 7.1
+  - 7.2
+  - 7.3
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=7.1.3",
         "illuminate/support": "^5.6",
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^7.0|^8.0",
+        "phpunit/phpunit": "^7.0",
         "symfony/css-selector": "~4.0",
         "symfony/dom-crawler": "~4.0"
     },


### PR DESCRIPTION
It turns out that installs of PHPUnit 8 are currently not possible because we override the setUp method and its signature has changed. This commit reverst the ability to install PHPUnit 8 since it won't work anyway.

In a follow-up commit I'll send in support for PHPUnit 8 on the next release branch.

This only requires a patch release.