### PR TITLE
[5.0] Provide PHPUnit 8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,23 @@
 language: php
 
-php:
-  - 7.1
-  - 7.2
-  - 7.3
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.1
+      env: PHPUNIT=^7.0
+    - php: 7.2
+      env: PHPUNIT=^7.0
+    - php: 7.2
+      env: PHPUNIT=^8.0
+    - php: 7.3
+      env: PHPUNIT=^7.0
+    - php: 7.3
+      env: PHPUNIT=^8.0
 
 sudo: false
 
-install: travis_retry composer install --no-interaction --prefer-dist --no-suggest
+install:
+  - travis_retry composer install --no-interaction --prefer-dist --no-suggest
+  - travis_retry composer require phpunit/phpunit:$PHPUNIT --update-with-dependencies
 
 script: vendor/bin/phpunit --verbose

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,15 @@
         "illuminate/http": "^5.7",
         "illuminate/support": "^5.6",
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^7.0|^8.0",
         "symfony/console": "^4.2",
         "symfony/css-selector": "~4.0",
         "symfony/dom-crawler": "~4.0",
         "symfony/http-foundation": "^4.2",
         "symfony/http-kernel": "^4.2"
+    },
+    "require-dev": {
+        "laravel/framework": "~5.7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -67,7 +67,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         if (! $this->app) {
             $this->refreshApplication();
@@ -139,7 +139,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->app) {
             foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {

--- a/tests/TestCaseTest.php
+++ b/tests/TestCaseTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\BrowserKitTesting\Tests;
+
+use Illuminate\Foundation\Application;
+use Laravel\BrowserKitTesting\TestCase;
+
+class TestCaseTest extends TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createApplication()
+    {
+        return new Application();
+    }
+
+    public function test_refresh_application()
+    {
+        $this->refreshApplication();
+
+        $this->assertInstanceOf(Application::class, $this->app);
+    }
+}


### PR DESCRIPTION
This commit provides full compatibility with PHPUnit 8 while still maintaining compatibility with v7. This allows users to have an even easier upgrade path. We may remove support for v7 in a next release.

I've added a new test class which will fail if tested with PHPUnit 8 that indicates the required void return type on the `tearDown` and `setUp` methods.

Sending this to master because this is a breaking change.