### PR TITLE
[6.0] Always has a version to support upcoming version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
         "php": ">=7.1.3",
         "ext-dom": "*",
         "ext-json": "*",
-        "illuminate/database": "~5.7.0|~5.8.0",
-        "illuminate/http": "~5.7.0|~5.8.0",
-        "illuminate/support": "~5.7.0|~5.8.0",
+        "illuminate/database": "~5.7.0|~5.8.0|~5.9.0",
+        "illuminate/http": "~5.7.0|~5.8.0|~5.9.0",
+        "illuminate/support": "~5.7.0|~5.8.0|~5.9.0",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^7.0|^8.0",
         "symfony/console": "^4.2",
@@ -25,7 +25,7 @@
         "symfony/http-kernel": "^4.2"
     },
     "require-dev": {
-        "laravel/framework": "~5.7.0|~5.8.0"
+        "laravel/framework": "~5.7.0|~5.8.0|~5.9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This is critical to allow developers to test against the nightly Laravel version even if it's not stable yet. Imagine developing Laravel Framework 5.9.0 when `orchestra/testbench-core` doesn't even support it.