### PR TITLE
Add shouldReport to withoutExceptionHandling instance

### DIFF
--- a/src/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Concerns/InteractsWithExceptionHandling.php
@@ -47,6 +47,10 @@ trait InteractsWithExceptionHandling
             public function report(Exception $e)
             {
             }
+            
+            public function shouldReport(Exception $e)
+            {
+            }
 
             public function render($request, Exception $e)
             {


### PR DESCRIPTION
`shouldReport()` was added to the `ExceptionHandler` interface. When it is not present in this trait, it throws an error when calling withoutExceptionHandling().

See this PR on Laravel Framework: 
https://github.com/laravel/framework/pull/26193