### PR TITLE
replace deprecated PHPUnit assetArraySubset method with an extension …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "php": "^7.2",
         "ext-dom": "*",
         "ext-json": "*",
+        "dms/phpunit-arraysubset-asserts": "^0.1.0",
         "illuminate/contracts": "^6.0|^7.0",
         "illuminate/database": "^6.0|^7.0",
         "illuminate/http": "^6.0|^7.0",

--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -3,6 +3,7 @@
 namespace Laravel\BrowserKitTesting\Concerns;
 
 use Closure;
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
@@ -15,7 +16,8 @@ use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 trait MakesHttpRequests
 {
-    use InteractsWithPages;
+    use ArraySubsetAsserts,
+        InteractsWithPages;
 
     /**
      * The last response returned by the application.
@@ -425,7 +427,7 @@ trait MakesHttpRequests
      */
     protected function seeJsonSubset(array $data)
     {
-        $this->assertArraySubset($data, $this->decodeResponseJson());
+        self::assertArraySubset($data, $this->decodeResponseJson());
 
         return $this;
     }

--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -422,8 +422,6 @@ trait MakesHttpRequests
      *
      * @param  array  $data
      * @return $this
-     *
-     * @deprecated This method will be removed in 5.0
      */
     protected function seeJsonSubset(array $data)
     {


### PR DESCRIPTION
As of version 9 of PHPUnit, the method `assertArraySubset()` will be deprecated, and version 8 throws a warning if this assertion is used.

This PR is replacing the deprecated method (used in `seeJsonSubset()`) with [this](https://github.com/rdohms/phpunit-arraysubset-asserts) PHPUnit extension, as suggested by the PHPUnit maintainer in this issue: [https://github.com/sebastianbergmann/phpunit/issues/3494#issuecomment-480283612](https://github.com/sebastianbergmann/phpunit/issues/3494#issuecomment-480283612)

