### PR TITLE
[6.0] Keep cookies between redirects

### DIFF
--- a/src/Concerns/InteractsWithPages.php
+++ b/src/Concerns/InteractsWithPages.php
@@ -19,6 +19,7 @@ use Laravel\BrowserKitTesting\HttpException;
 use PHPUnit\Framework\ExpectationFailedException as PHPUnitException;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Form;
+use Symfony\Component\HttpFoundation\Cookie;
 
 trait InteractsWithPages
 {
@@ -147,7 +148,14 @@ trait InteractsWithPages
     protected function followRedirects()
     {
         while ($this->response->isRedirect()) {
-            $this->makeRequest('GET', $this->response->getTargetUrl());
+            $this->makeRequest(
+                'GET',
+                $this->response->getTargetUrl(),
+                [],
+                collect($this->response->headers->getCookies())->mapWithKeys(function (Cookie $cookie) {
+                    return [$cookie->getName() => $cookie->getValue()];
+                })->all()
+            );
         }
 
         return $this;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull request makes `followRedirects` keep the cookies from the response when requesting to the new location.

I think the follow redirects should behave as browsers and all modern browsers keep the cookies after a redirect.

The changes should not break any existing code, but I am open to make it configurable via opt-in.
