### PR TITLE
[6.x] Symfony 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,10 @@ php:
 
 env:
   matrix:
-    - LARAVEL=^6.0 PHPUNIT=^7.0
-    - LARAVEL=^6.0 PHPUNIT=^8.0
     - LARAVEL=^7.0 PHPUNIT=^8.0
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: LARAVEL=^7.0 PHPUNIT=^8.0
 
 before_install:
   - phpenv config-rm xdebug.ini || true

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
         "illuminate/support": "^6.0|^7.0",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^7.0|^8.0",
-        "symfony/console": "^4.3",
-        "symfony/css-selector": "^4.3",
-        "symfony/dom-crawler": "^4.3",
-        "symfony/http-foundation": "^4.3",
-        "symfony/http-kernel": "^4.3"
+        "symfony/console": "^5.0",
+        "symfony/css-selector": "^5.0",
+        "symfony/dom-crawler": "^5.0",
+        "symfony/http-foundation": "^5.0",
+        "symfony/http-kernel": "^5.0"
     },
     "require-dev": {
         "laravel/framework": "^6.0|^7.0"
@@ -48,6 +48,5 @@
         "sort-packages": true,
         "optimize-autoloader": true
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "illuminate/http": "^7.0",
         "illuminate/support": "^7.0",
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^7.0|^8.0",
+        "phpunit/phpunit": "^8.0",
         "symfony/console": "^5.0",
         "symfony/css-selector": "^5.0",
         "symfony/dom-crawler": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
         "php": "^7.2",
         "ext-dom": "*",
         "ext-json": "*",
-        "illuminate/contracts": "^6.0|^7.0",
-        "illuminate/database": "^6.0|^7.0",
-        "illuminate/http": "^6.0|^7.0",
-        "illuminate/support": "^6.0|^7.0",
+        "illuminate/contracts": "^7.0",
+        "illuminate/database": "^7.0",
+        "illuminate/http": "^7.0",
+        "illuminate/support": "^7.0",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^7.0|^8.0",
         "symfony/console": "^5.0",
@@ -26,7 +26,7 @@
         "symfony/http-kernel": "^5.0"
     },
     "require-dev": {
-        "laravel/framework": "^6.0|^7.0"
+        "laravel/framework": "^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -48,5 +48,6 @@
         "sort-packages": true,
         "optimize-autoloader": true
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/src/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Concerns/InteractsWithExceptionHandling.php
@@ -2,10 +2,10 @@
 
 namespace Laravel\BrowserKitTesting\Concerns;
 
-use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Throwable;
 
 trait InteractsWithExceptionHandling
 {
@@ -44,16 +44,16 @@ trait InteractsWithExceptionHandling
             {
             }
 
-            public function report(Exception $e)
+            public function report(Throwable $e)
             {
             }
 
-            public function shouldReport(Exception $e)
+            public function shouldReport(Throwable $e)
             {
                 return false;
             }
 
-            public function render($request, Exception $e)
+            public function render($request, Throwable $e)
             {
                 if ($e instanceof NotFoundHttpException) {
                     throw new NotFoundHttpException(
@@ -64,9 +64,9 @@ trait InteractsWithExceptionHandling
                 throw $e;
             }
 
-            public function renderForConsole($output, Exception $e)
+            public function renderForConsole($output, Throwable $e)
             {
-                (new ConsoleApplication)->renderException($e, $output);
+                (new ConsoleApplication)->renderThrowable($e, $output);
             }
         });
 

--- a/src/Concerns/InteractsWithPages.php
+++ b/src/Concerns/InteractsWithPages.php
@@ -774,7 +774,7 @@ trait InteractsWithPages
         $originalName = isset($uploads[$name]) ? basename($uploads[$name]) : $file['name'];
 
         return new UploadedFile(
-            $file['tmp_name'], $originalName, $file['type'], $file['size'], $file['error'], true
+            $file['tmp_name'], $originalName, $file['type'], $file['error'], true
         );
     }
 }

--- a/tests/Stubs/ExceptionHandlerStub.php
+++ b/tests/Stubs/ExceptionHandlerStub.php
@@ -2,10 +2,10 @@
 
 namespace Laravel\BrowserKitTesting\Tests\Stubs;
 
-use Throwable;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Throwable;
 
 class ExceptionHandlerStub implements ExceptionHandler
 {

--- a/tests/Stubs/ExceptionHandlerStub.php
+++ b/tests/Stubs/ExceptionHandlerStub.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\BrowserKitTesting\Tests\Stubs;
 
-use Exception;
+use Throwable;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -13,16 +13,16 @@ class ExceptionHandlerStub implements ExceptionHandler
     {
     }
 
-    public function report(Exception $e)
+    public function report(Throwable $e)
     {
     }
 
-    public function shouldReport(Exception $e)
+    public function shouldReport(Throwable $e)
     {
         return false;
     }
 
-    public function render($request, Exception $e)
+    public function render($request, Throwable $e)
     {
         if ($e instanceof NotFoundHttpException) {
             throw new NotFoundHttpException(
@@ -33,7 +33,7 @@ class ExceptionHandlerStub implements ExceptionHandler
         throw $e;
     }
 
-    public function renderForConsole($output, Exception $e)
+    public function renderForConsole($output, Throwable $e)
     {
         (new ConsoleApplication)->renderException($e, $output);
     }

--- a/tests/Unit/InteractsWithPagesTest.php
+++ b/tests/Unit/InteractsWithPagesTest.php
@@ -452,7 +452,7 @@ class InteractsWithPagesTest extends TestCase
         );
         $this->assertEquals('avatar.png', $file->getClientOriginalName());
         $this->assertEquals('txt/plain', $file->getClientMimeType());
-        $this->assertEquals(0, $file->getClientSize());
+        $this->assertEquals(0, $file->getSize());
     }
 
     public function attributes_UploadedFile()


### PR DESCRIPTION
This PR:

- Updates Symfony to 5.0
- Drops support for Laravel 6.x
- Drops support for PHPUnit 7