### PR TITLE
[6.x] Remove deprecated method so we don't have to deal with assertArraySubset.

### DIFF
--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -416,21 +416,6 @@ trait MakesHttpRequests
     }
 
     /**
-     * Assert that the response is a superset of the given JSON.
-     *
-     * @param  array  $data
-     * @return $this
-     *
-     * @deprecated This method will be removed in 5.0
-     */
-    protected function seeJsonSubset(array $data)
-    {
-        $this->assertArraySubset($data, $this->decodeResponseJson());
-
-        return $this;
-    }
-
-    /**
      * Validate and return the decoded response JSON.
      *
      * @return array


### PR DESCRIPTION
Initially it was marked to be removed in 5.0 but might have been forgotten.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
