### PR TITLE
[6.x] Utilise illuminate/testing based on #122

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "illuminate/database": "^7.0",
         "illuminate/http": "^7.0",
         "illuminate/support": "^7.0",
+        "illuminate/testing": "^7.0",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^8.4|^9.0",
         "symfony/console": "^5.0",

--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -2,14 +2,10 @@
 
 namespace Laravel\BrowserKitTesting\Concerns;
 
-use Closure;
-use Illuminate\Contracts\View\View;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Laravel\BrowserKitTesting\TestResponse;
-use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\ExpectationFailedException;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;

--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -381,22 +381,6 @@ trait MakesHttpRequests
     }
 
     /**
-     * Validate and return the decoded response JSON.
-     *
-     * @return array
-     */
-    protected function decodeResponseJson()
-    {
-        $decodedResponse = json_decode($this->response->getContent(), true);
-
-        if (is_null($decodedResponse) || $decodedResponse === false) {
-            $this->fail('Invalid JSON was returned from the route. Perhaps an exception was thrown?');
-        }
-
-        return $decodedResponse;
-    }
-
-    /**
      * Asserts that the status code of the response matches the given code.
      *
      * @param  int  $status

--- a/src/TestResponse.php
+++ b/src/TestResponse.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Laravel\BrowserKitTesting;
+
+class TestResponse extends \Illuminate\Testing\TestResponse
+{
+    /**
+     * Assert that the client response has an OK status code.
+     *
+     * @return $this
+     */
+    public function assertResponseOk()
+    {
+        return $this->assertOk();
+    }
+
+    /**
+     * Assert that the client response has a given code.
+     *
+     * @param  int  $code
+     * @return $this
+     */
+    public function assertResponseStatus($code)
+    {
+        return $this->assertStatus($code);
+    }
+
+    /**
+     * Assert whether the client was redirected to a given URI.
+     *
+     * @param  string  $uri
+     * @param  array  $with
+     * @return $this
+     */
+    public function assertRedirectedTo($uri, $with = [])
+    {
+        PHPUnit::assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $this->baseResponse);
+
+        $this->assertRedirect($uri);
+
+        $this->assertSessionHasAll($with);
+
+        return $this;
+    }
+
+    /**
+     * Assert whether the client was redirected to a given route.
+     *
+     * @param  string  $name
+     * @param  array  $parameters
+     * @param  array  $with
+     * @return $this
+     */
+    public function assertRedirectedToRoute($name, $parameters = [], $with = [])
+    {
+        return $this->assertRedirectedTo(app('url')->route($name, $parameters), $with);
+    }
+
+    /**
+     * Assert whether the client was redirected to a given action.
+     *
+     * @param  string  $name
+     * @param  array  $parameters
+     * @param  array  $with
+     * @return $this
+     */
+    public function assertRedirectedToAction($name, $parameters = [], $with = [])
+    {
+        return $this->assertRedirectedTo(app('url')->action($name, $parameters), $with);
+    }
+}

--- a/src/TestResponse.php
+++ b/src/TestResponse.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\BrowserKitTesting;
 
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
 class TestResponse extends \Illuminate\Testing\TestResponse
 {
     /**
@@ -34,7 +36,7 @@ class TestResponse extends \Illuminate\Testing\TestResponse
      */
     public function assertRedirectedTo($uri, $with = [])
     {
-        PHPUnit::assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $this->baseResponse);
+        PHPUnit::assertInstanceOf(RedirectResponse::class, $this->baseResponse);
 
         $this->assertRedirect($uri);
 

--- a/tests/Unit/MakesHttpRequestsTest.php
+++ b/tests/Unit/MakesHttpRequestsTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\BrowserKitTesting\Tests\Unit;
 
 use Laravel\BrowserKitTesting\Concerns\MakesHttpRequests;
+use Laravel\BrowserKitTesting\TestResponse;
 use Laravel\BrowserKitTesting\Tests\TestCase;
 use PHPUnit\Framework\ExpectationFailedException;
 
@@ -40,12 +41,13 @@ class MakesHttpRequestsTest extends TestCase
      */
     public function seeStatusCode_check_status_code()
     {
-        $this->response = new class {
+        $this->response = TestResponse::fromBaseResponse(new class {
             public function getStatusCode()
             {
                 return 200;
             }
-        };
+        });
+
         $this->seeStatusCode(200);
     }
 
@@ -54,7 +56,7 @@ class MakesHttpRequestsTest extends TestCase
      */
     public function assertResponseOk_check_that_the_status_page_should_be_200()
     {
-        $this->response = new class {
+        $this->response = TestResponse::fromBaseResponse(new class {
             public function getStatusCode()
             {
                 return 200;
@@ -64,8 +66,9 @@ class MakesHttpRequestsTest extends TestCase
             {
                 return true;
             }
-        };
-        $this->assertResponseOk();
+        });
+
+        $this->response->assertResponseOk();
     }
 
     /**
@@ -74,9 +77,9 @@ class MakesHttpRequestsTest extends TestCase
     public function assertResponseOk_throw_exception_when_the_status_page_is_not_200()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Expected status code 200, got 404.');
+        $this->expectExceptionMessage('Response status code [404] does not match expected 200 status code.');
 
-        $this->response = new class {
+        $this->response = TestResponse::fromBaseResponse(new class {
             public function getStatusCode()
             {
                 return 404;
@@ -86,8 +89,9 @@ class MakesHttpRequestsTest extends TestCase
             {
                 return false;
             }
-        };
-        $this->assertResponseOk();
+        });
+
+        $this->response->assertResponseOk();
     }
 
     /**
@@ -95,13 +99,14 @@ class MakesHttpRequestsTest extends TestCase
      */
     public function assertResponseStatus_check_the_response_status_is_equal_to_passed_by_parameter()
     {
-        $this->response = new class {
+        $this->response = TestResponse::fromBaseResponse(new class {
             public function getStatusCode()
             {
                 return 200;
             }
-        };
-        $this->assertResponseStatus(200);
+        });
+
+        $this->response->assertResponseStatus(200);
     }
 
     /**
@@ -110,14 +115,15 @@ class MakesHttpRequestsTest extends TestCase
     public function assertResponseStatus_throw_exception_when_the_response_status_is_not_equal_to_passed_by_parameter()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Expected status code 404, got 200.');
+        $this->expectExceptionMessage('Expected status code 404 but received 200.');
 
-        $this->response = new class {
+        $this->response = TestResponse::fromBaseResponse(new class {
             public function getStatusCode()
             {
                 return 200;
             }
-        };
-        $this->assertResponseStatus(404);
+        });
+
+        $this->response->assertResponseStatus(404);
     }
 }


### PR DESCRIPTION
There no breaking changes so far but we could clean-up some of the `seeJson***` assertions which is available from `TestResponse`.


Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
