### PR TITLE
[6.x] Utilise illuminate/testing based on #122

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "illuminate/database": "^7.0",
         "illuminate/http": "^7.0",
         "illuminate/support": "^7.0",
+        "illuminate/testing": "^7.0",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^8.4|^9.0",
         "symfony/console": "^5.0",

--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -2,13 +2,10 @@
 
 namespace Laravel\BrowserKitTesting\Concerns;
 
-use Closure;
-use Illuminate\Contracts\View\View;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use PHPUnit\Framework\Assert as PHPUnit;
+use Laravel\BrowserKitTesting\TestResponse;
 use PHPUnit\Framework\ExpectationFailedException;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
@@ -274,7 +271,9 @@ trait MakesHttpRequests
     {
         $this->currentUri = $request->fullUrl();
 
-        $this->response = $this->app->prepareResponse($this->app->handle($request));
+        $this->response = TestResponse::fromBaseResponse(
+            $this->app->prepareResponse($this->app->handle($request))
+        );
 
         return $this;
     }
@@ -309,11 +308,7 @@ trait MakesHttpRequests
      */
     public function seeJsonEquals(array $data)
     {
-        $actual = json_encode(Arr::sortRecursive(
-            (array) $this->decodeResponseJson()
-        ));
-
-        $this->assertEquals(json_encode(Arr::sortRecursive($data)), $actual);
+        $this->response->assertExactJson($data);
 
         return $this;
     }
@@ -362,28 +357,7 @@ trait MakesHttpRequests
      */
     public function seeJsonStructure(array $structure = null, $responseData = null)
     {
-        if (is_null($structure)) {
-            return $this->seeJson();
-        }
-
-        if (is_null($responseData)) {
-            $responseData = $this->decodeResponseJson();
-        }
-
-        foreach ($structure as $key => $value) {
-            if (is_array($value) && $key === '*') {
-                $this->assertIsArray($responseData);
-
-                foreach ($responseData as $responseDataItem) {
-                    $this->seeJsonStructure($structure['*'], $responseDataItem);
-                }
-            } elseif (is_array($value)) {
-                $this->assertArrayHasKey($key, $responseData);
-                $this->seeJsonStructure($structure[$key], $responseData[$key]);
-            } else {
-                $this->assertArrayHasKey($value, $responseData);
-            }
-        }
+        $this->response->assertJsonStructure($structure, $responseData);
 
         return $this;
     }
@@ -397,60 +371,13 @@ trait MakesHttpRequests
      */
     protected function seeJsonContains(array $data, $negate = false)
     {
-        $method = $negate ? 'assertFalse' : 'assertTrue';
-
-        $actual = json_encode(Arr::sortRecursive(
-            (array) $this->decodeResponseJson()
-        ));
-
-        foreach (Arr::sortRecursive($data) as $key => $value) {
-            $expected = $this->formatToExpectedJson($key, $value);
-
-            $this->{$method}(
-                Str::contains($actual, $expected),
-                ($negate ? 'Found unexpected' : 'Unable to find').' JSON fragment'.PHP_EOL."[{$expected}]".PHP_EOL.'within'.PHP_EOL."[{$actual}]."
-            );
+        if ($negate) {
+            $this->response->assertJsonMissing($data, false);
+        } else {
+            $this->response->assertJsonFragment($data);
         }
 
         return $this;
-    }
-
-    /**
-     * Validate and return the decoded response JSON.
-     *
-     * @return array
-     */
-    protected function decodeResponseJson()
-    {
-        $decodedResponse = json_decode($this->response->getContent(), true);
-
-        if (is_null($decodedResponse) || $decodedResponse === false) {
-            $this->fail('Invalid JSON was returned from the route. Perhaps an exception was thrown?');
-        }
-
-        return $decodedResponse;
-    }
-
-    /**
-     * Format the given key and value into a JSON string for expectation checks.
-     *
-     * @param  string  $key
-     * @param  mixed  $value
-     * @return string
-     */
-    protected function formatToExpectedJson($key, $value)
-    {
-        $expected = json_encode([$key => $value]);
-
-        if (Str::startsWith($expected, '{')) {
-            $expected = substr($expected, 1);
-        }
-
-        if (Str::endsWith($expected, '}')) {
-            $expected = substr($expected, 0, -1);
-        }
-
-        return trim($expected);
     }
 
     /**
@@ -461,7 +388,7 @@ trait MakesHttpRequests
      */
     protected function seeStatusCode($status)
     {
-        $this->assertEquals($status, $this->response->getStatusCode());
+        $this->response->assertStatus($status);
 
         return $this;
     }
@@ -475,16 +402,7 @@ trait MakesHttpRequests
      */
     protected function seeHeader($headerName, $value = null)
     {
-        $headers = $this->response->headers;
-
-        $this->assertTrue($headers->has($headerName), "Header [{$headerName}] not present on response.");
-
-        if (! is_null($value)) {
-            $this->assertEquals(
-                $headers->get($headerName), $value,
-                "Header [{$headerName}] was found, but value [{$headers->get($headerName)}] does not match [{$value}]."
-            );
-        }
+        $this->response->assertHeader($headerName, $value);
 
         return $this;
     }
@@ -512,32 +430,7 @@ trait MakesHttpRequests
      */
     protected function seeCookie($cookieName, $value = null, $encrypted = true, $unserialize = true)
     {
-        $headers = $this->response->headers;
-
-        $exist = false;
-
-        foreach ($headers->getCookies() as $cookie) {
-            if ($cookie->getName() === $cookieName) {
-                $exist = true;
-                break;
-            }
-        }
-
-        $this->assertTrue($exist, "Cookie [{$cookieName}] not present on response.");
-
-        if (! $exist || is_null($value)) {
-            return $this;
-        }
-
-        $cookieValue = $cookie->getValue();
-
-        $actual = $encrypted
-            ? $this->app['encrypter']->decrypt($cookieValue, $unserialize) : $cookieValue;
-
-        $this->assertEquals(
-            $actual, $value,
-            "Cookie [{$cookieName}] was found, but value [{$actual}] does not match [{$value}]."
-        );
+        $this->response->assertCookie($cookieName, $value, $encrypted, $unserialize);
 
         return $this;
     }
@@ -586,7 +479,7 @@ trait MakesHttpRequests
 
         $kernel->terminate($request, $response);
 
-        return $this->response = $response;
+        return $this->response = TestResponse::fromBaseResponse($response);
     }
 
     /**
@@ -605,7 +498,7 @@ trait MakesHttpRequests
     {
         $uri = $this->app['url']->secure(ltrim($uri, '/'));
 
-        return $this->response = $this->call($method, $uri, $parameters, $cookies, $files, $server, $content);
+        return $this->call($method, $uri, $parameters, $cookies, $files, $server, $content);
     }
 
     /**
@@ -625,7 +518,7 @@ trait MakesHttpRequests
     {
         $uri = $this->app['url']->action($action, $wildcards, true);
 
-        return $this->response = $this->call($method, $uri, $parameters, $cookies, $files, $server, $content);
+        return $this->call($method, $uri, $parameters, $cookies, $files, $server, $content);
     }
 
     /**
@@ -645,7 +538,7 @@ trait MakesHttpRequests
     {
         $uri = $this->app['url']->route($name, $routeParameters);
 
-        return $this->response = $this->call($method, $uri, $parameters, $cookies, $files, $server, $content);
+        return $this->call($method, $uri, $parameters, $cookies, $files, $server, $content);
     }
 
     /**
@@ -727,9 +620,7 @@ trait MakesHttpRequests
      */
     public function assertResponseOk()
     {
-        $actual = $this->response->getStatusCode();
-
-        PHPUnit::assertTrue($this->response->isOk(), "Expected status code 200, got {$actual}.");
+        $this->response->assertResponseOk();
 
         return $this;
     }
@@ -742,9 +633,7 @@ trait MakesHttpRequests
      */
     public function assertResponseStatus($code)
     {
-        $actual = $this->response->getStatusCode();
-
-        PHPUnit::assertEquals($code, $this->response->getStatusCode(), "Expected status code {$code}, got {$actual}.");
+        $this->response->assertStatus($code);
 
         return $this;
     }
@@ -758,21 +647,7 @@ trait MakesHttpRequests
      */
     public function assertViewHas($key, $value = null)
     {
-        if (is_array($key)) {
-            return $this->assertViewHasAll($key);
-        }
-
-        if (! isset($this->response->original) || ! $this->response->original instanceof View) {
-            return PHPUnit::assertTrue(false, 'The response was not a view.');
-        }
-
-        if (is_null($value)) {
-            PHPUnit::assertArrayHasKey($key, $this->response->original->getData());
-        } elseif ($value instanceof Closure) {
-            PHPUnit::assertTrue($value($this->response->original->$key));
-        } else {
-            PHPUnit::assertEquals($value, $this->response->original->$key);
-        }
+        $this->response->assertViewHas($key, $value);
 
         return $this;
     }
@@ -785,13 +660,7 @@ trait MakesHttpRequests
      */
     public function assertViewHasAll(array $bindings)
     {
-        foreach ($bindings as $key => $value) {
-            if (is_int($key)) {
-                $this->assertViewHas($value);
-            } else {
-                $this->assertViewHas($key, $value);
-            }
-        }
+        $this->response->assertViewHasAll($bindings);
 
         return $this;
     }
@@ -804,11 +673,7 @@ trait MakesHttpRequests
      */
     public function assertViewMissing($key)
     {
-        if (! isset($this->response->original) || ! $this->response->original instanceof View) {
-            return PHPUnit::assertTrue(false, 'The response was not a view.');
-        }
-
-        PHPUnit::assertArrayNotHasKey($key, $this->response->original->getData());
+        $this->response->assertViewMissing($key);
 
         return $this;
     }
@@ -822,11 +687,7 @@ trait MakesHttpRequests
      */
     public function assertRedirectedTo($uri, $with = [])
     {
-        PHPUnit::assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $this->response);
-
-        PHPUnit::assertEquals($this->app['url']->to($uri), $this->response->headers->get('Location'));
-
-        $this->assertSessionHasAll($with);
+        $this->response->assertRedirectedTo($uri, $with);
 
         return $this;
     }
@@ -841,7 +702,9 @@ trait MakesHttpRequests
      */
     public function assertRedirectedToRoute($name, $parameters = [], $with = [])
     {
-        return $this->assertRedirectedTo($this->app['url']->route($name, $parameters), $with);
+        $this->response->assertRedirectedToRoute($name, $parameters, $with);
+
+        return $this;
     }
 
     /**
@@ -854,7 +717,9 @@ trait MakesHttpRequests
      */
     public function assertRedirectedToAction($name, $parameters = [], $with = [])
     {
-        return $this->assertRedirectedTo($this->app['url']->action($name, $parameters), $with);
+        $this->response->assertRedirectedToAction($name, $parameters, $with);
+
+        return $this;
     }
 
     /**
@@ -864,14 +729,6 @@ trait MakesHttpRequests
      */
     public function dump()
     {
-        $content = $this->response->getContent();
-
-        $json = json_decode($content);
-
-        if (json_last_error() === JSON_ERROR_NONE) {
-            $content = $json;
-        }
-
-        dd($content);
+        $this->response->dump();
     }
 }

--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -324,11 +324,13 @@ trait MakesHttpRequests
     public function seeJson(array $data = null, $negate = false)
     {
         if (is_null($data)) {
-            PHPUnit::assertArraySubset(
-                null, json_decode($this->getContent(), true), false, "JSON was not returned from [{$this->currentUri}]."
-            );
+            $decodedResponse = json_decode($this->response->getContent(), true);
 
-            return $this;
+            if (is_null($decodedResponse) || $decodedResponse === false) {
+                PHPUnit::fail(
+                    "JSON was not returned from [{$this->currentUri}]."
+                );
+            }
         }
 
         try {

--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -5,6 +5,7 @@ namespace Laravel\BrowserKitTesting\Concerns;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Str;
+use Illuminate\Testing\PHPUnit;
 use Laravel\BrowserKitTesting\TestResponse;
 use PHPUnit\Framework\ExpectationFailedException;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
@@ -323,8 +324,8 @@ trait MakesHttpRequests
     public function seeJson(array $data = null, $negate = false)
     {
         if (is_null($data)) {
-            $this->assertJson(
-                $this->response->getContent(), "JSON was not returned from [{$this->currentUri}]."
+            PHPUnit::assertArraySubset(
+                null, json_decode($this->getContent(), true), false, "JSON was not returned from [{$this->currentUri}]."
             );
 
             return $this;

--- a/src/TestResponse.php
+++ b/src/TestResponse.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Laravel\BrowserKitTesting;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+class TestResponse extends \Illuminate\Testing\TestResponse
+{
+    /**
+     * Assert that the client response has an OK status code.
+     *
+     * @return $this
+     */
+    public function assertResponseOk()
+    {
+        return $this->assertOk();
+    }
+
+    /**
+     * Assert that the client response has a given code.
+     *
+     * @param  int  $code
+     * @return $this
+     */
+    public function assertResponseStatus($code)
+    {
+        return $this->assertStatus($code);
+    }
+
+    /**
+     * Assert whether the client was redirected to a given URI.
+     *
+     * @param  string  $uri
+     * @param  array  $with
+     * @return $this
+     */
+    public function assertRedirectedTo($uri, $with = [])
+    {
+        PHPUnit::assertInstanceOf(RedirectResponse::class, $this->baseResponse);
+
+        $this->assertRedirect($uri);
+
+        $this->assertSessionHasAll($with);
+
+        return $this;
+    }
+
+    /**
+     * Assert whether the client was redirected to a given route.
+     *
+     * @param  string  $name
+     * @param  array  $parameters
+     * @param  array  $with
+     * @return $this
+     */
+    public function assertRedirectedToRoute($name, $parameters = [], $with = [])
+    {
+        return $this->assertRedirectedTo(app('url')->route($name, $parameters), $with);
+    }
+
+    /**
+     * Assert whether the client was redirected to a given action.
+     *
+     * @param  string  $name
+     * @param  array  $parameters
+     * @param  array  $with
+     * @return $this
+     */
+    public function assertRedirectedToAction($name, $parameters = [], $with = [])
+    {
+        return $this->assertRedirectedTo(app('url')->action($name, $parameters), $with);
+    }
+}

--- a/tests/Unit/MakesHttpRequestsTest.php
+++ b/tests/Unit/MakesHttpRequestsTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\BrowserKitTesting\Tests\Unit;
 
 use Laravel\BrowserKitTesting\Concerns\MakesHttpRequests;
+use Laravel\BrowserKitTesting\TestResponse;
 use Laravel\BrowserKitTesting\Tests\TestCase;
 use PHPUnit\Framework\ExpectationFailedException;
 
@@ -40,12 +41,13 @@ class MakesHttpRequestsTest extends TestCase
      */
     public function seeStatusCode_check_status_code()
     {
-        $this->response = new class {
+        $this->response = TestResponse::fromBaseResponse(new class {
             public function getStatusCode()
             {
                 return 200;
             }
-        };
+        });
+
         $this->seeStatusCode(200);
     }
 
@@ -54,7 +56,7 @@ class MakesHttpRequestsTest extends TestCase
      */
     public function assertResponseOk_check_that_the_status_page_should_be_200()
     {
-        $this->response = new class {
+        $this->response = TestResponse::fromBaseResponse(new class {
             public function getStatusCode()
             {
                 return 200;
@@ -64,8 +66,9 @@ class MakesHttpRequestsTest extends TestCase
             {
                 return true;
             }
-        };
-        $this->assertResponseOk();
+        });
+
+        $this->response->assertResponseOk();
     }
 
     /**
@@ -74,9 +77,9 @@ class MakesHttpRequestsTest extends TestCase
     public function assertResponseOk_throw_exception_when_the_status_page_is_not_200()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Expected status code 200, got 404.');
+        $this->expectExceptionMessage('Response status code [404] does not match expected 200 status code.');
 
-        $this->response = new class {
+        $this->response = TestResponse::fromBaseResponse(new class {
             public function getStatusCode()
             {
                 return 404;
@@ -86,8 +89,9 @@ class MakesHttpRequestsTest extends TestCase
             {
                 return false;
             }
-        };
-        $this->assertResponseOk();
+        });
+
+        $this->response->assertResponseOk();
     }
 
     /**
@@ -95,13 +99,14 @@ class MakesHttpRequestsTest extends TestCase
      */
     public function assertResponseStatus_check_the_response_status_is_equal_to_passed_by_parameter()
     {
-        $this->response = new class {
+        $this->response = TestResponse::fromBaseResponse(new class {
             public function getStatusCode()
             {
                 return 200;
             }
-        };
-        $this->assertResponseStatus(200);
+        });
+
+        $this->response->assertResponseStatus(200);
     }
 
     /**
@@ -110,14 +115,15 @@ class MakesHttpRequestsTest extends TestCase
     public function assertResponseStatus_throw_exception_when_the_response_status_is_not_equal_to_passed_by_parameter()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Expected status code 404, got 200.');
+        $this->expectExceptionMessage('Expected status code 404 but received 200.');
 
-        $this->response = new class {
+        $this->response = TestResponse::fromBaseResponse(new class {
             public function getStatusCode()
             {
                 return 200;
             }
-        };
-        $this->assertResponseStatus(404);
+        });
+
+        $this->response->assertResponseStatus(404);
     }
 }


### PR DESCRIPTION
### Changelog note

All HTTP tests will now return an instance of `Laravel\BrowserKitTesting\TestResponse` instead of `Illuminate\Http\Response`. The advantage of having TestResponse is that you have access to every assertion available in [Laravel HTTP Tests > Response Assertions](https://laravel.com/docs/master/http-tests#response-assertions).

------

This PR no longer add any breaking change. Old and new methods can be used.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
