### PR TITLE
[6.x] Fix invalid Illuminate\Testing\Assert import

### DIFF
--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -5,7 +5,7 @@ namespace Laravel\BrowserKitTesting\Concerns;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Str;
-use Illuminate\Testing\PHPUnit;
+use Illuminate\Testing\Assert as PHPUnit;
 use Laravel\BrowserKitTesting\TestResponse;
 use PHPUnit\Framework\ExpectationFailedException;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;

--- a/src/TestResponse.php
+++ b/src/TestResponse.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\BrowserKitTesting;
 
+use Illuminate\Testing\Assert as PHPUnit;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class TestResponse extends \Illuminate\Testing\TestResponse


### PR DESCRIPTION
My bad, just found it out while testing my packages with dev-master

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
