### PR TITLE
[6.x] allow APP_ENV to be defined by the environment

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -93,8 +93,6 @@ abstract class TestCase extends BaseTestCase
      */
     protected function refreshApplication()
     {
-        putenv('APP_ENV=testing');
-
         $this->app = $this->createApplication();
     }
 

--- a/tests/TestCaseTest.php
+++ b/tests/TestCaseTest.php
@@ -21,4 +21,13 @@ class TestCaseTest extends TestCase
 
         $this->assertInstanceOf(Application::class, $this->app);
     }
+    
+    public function test_refresh_application_does_not_override_app_env()
+    {
+	putenv('APP_ENV=foo');
+
+	$this->refreshApplication();
+
+	$this->assertEquals('foo', getenv('APP_ENV'));
+    }
 }


### PR DESCRIPTION
`APP_ENV` is an environment variable that Laravel uses to determine which `.env` file to load when creating the application. The test case hardcodes this to `testing` which prevents the system environment variable from having the desired effect of picking the correct `.env` file when running my tests in CI. 

I have basically removed the line that does this, which means that tests will now pick up the correct environment file in line with how Laravel works. Given that this is also set by default in the environment variables of `phpunit.xml`, I think it's reasonable to have simply removed this, rather than trying to do something more defensive with the change.
