### PR TITLE
[5.x] Remove cookie prefix in seeCookie

### DIFF
--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -643,7 +643,6 @@ trait MakesHttpRequests
         $actual = $encrypted
             ? $this->app['encrypter']->decrypt($cookieValue, $unserialize) : $cookieValue;
 
-        // remove the prefix from the cookie
         $hasValidPrefix = strpos($actual, CookieValuePrefix::create($cookieName, app('encrypter')->getKey())) === 0;
 
         $actual = $hasValidPrefix ? CookieValuePrefix::remove($actual) : null;

--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -642,7 +642,7 @@ trait MakesHttpRequests
 
         $actual = $encrypted
             ? $this->app['encrypter']->decrypt($cookieValue, $unserialize) : $cookieValue;
-        
+
         // remove the prefix from the cookie
         $hasValidPrefix = strpos($actual, CookieValuePrefix::create($cookieName, app('encrypter')->getKey())) === 0;
 

--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -619,7 +619,7 @@ trait MakesHttpRequests
      * @param  bool  $unserialize
      * @return $this
      */
-    protected function seeCookie($cookieName, $value = null, $encrypted = true, $unserialize = true)
+    protected function seeCookie($cookieName, $value = null, $encrypted = true, $unserialize = false)
     {
         $headers = $this->response->headers;
 
@@ -642,6 +642,11 @@ trait MakesHttpRequests
 
         $actual = $encrypted
             ? $this->app['encrypter']->decrypt($cookieValue, $unserialize) : $cookieValue;
+        
+        // remove the prefix from the cookie
+        $hasValidPrefix = strpos($actual, CookieValuePrefix::create($cookieName, app('encrypter')->getKey())) === 0;
+
+        $actual = $hasValidPrefix ? CookieValuePrefix::remove($actual) : null;
 
         $this->assertEquals(
             $actual, $value,


### PR DESCRIPTION
Disable unserialize by default since laravel no longer serializes cookies by default.

Make sure the cookie prefix is removed before asserting the value.