### PR TITLE
Improve assertions

### DIFF
--- a/tests/Unit/InteractsWithConsoleTest.php
+++ b/tests/Unit/InteractsWithConsoleTest.php
@@ -24,12 +24,12 @@ class InteractsWithConsoleTest extends TestCase
         $command = 'app:user';
         $parameters = ['name' => 'john'];
 
-        $this->assertEquals(
+        $this->assertSame(
             'User was created.',
             $this->artisan($command, $parameters)
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             $this->code,
             $this->app[Kernel::class]->call($command, $parameters)
         );

--- a/tests/Unit/InteractsWithDatabaseTest.php
+++ b/tests/Unit/InteractsWithDatabaseTest.php
@@ -109,7 +109,7 @@ class InteractsWithDatabaseTest extends TestCase
             }
         };
         $this->seed();
-        $this->assertEquals(
+        $this->assertSame(
             'Seeding: DatabaseSeeder',
             $this->code
         );

--- a/tests/Unit/InteractsWithPagesTest.php
+++ b/tests/Unit/InteractsWithPagesTest.php
@@ -430,7 +430,7 @@ class InteractsWithPagesTest extends TestCase
         $this->createPage($body);
 
         $this->within('.card-user > h3', function () {
-            $this->assertEquals(
+            $this->assertSame(
                 'John Doe',
                 $this->crawler()->text()
             );
@@ -450,9 +450,9 @@ class InteractsWithPagesTest extends TestCase
             \Illuminate\Http\UploadedFile::class,
             $file
         );
-        $this->assertEquals('avatar.png', $file->getClientOriginalName());
-        $this->assertEquals('txt/plain', $file->getClientMimeType());
-        $this->assertEquals(0, $file->getSize());
+        $this->assertSame('avatar.png', $file->getClientOriginalName());
+        $this->assertSame('txt/plain', $file->getClientMimeType());
+        $this->assertSame(0, $file->getSize());
     }
 
     public function attributes_UploadedFile()


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and it can make assertion equals checking strict.