### PR TITLE
[6.x] Add missing import for CookieValuePrefix

### DIFF
--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\BrowserKitTesting\Concerns;
 
+use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Str;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR fixes the usage of the `withCookie()` / `withCookies()` methods. See error below:

```
Class 'Laravel\BrowserKitTesting\Concerns\CookieValuePrefix' not found

  at vendor/laravel/browser-kit-testing/src/Concerns/MakesHttpRequests.php:695
    691|             return array_merge($this->defaultCookies, $this->unencryptedCookies);
    692|         }
    693| 
    694|         return collect($this->defaultCookies)->map(function ($value, $key) {
  > 695|             return encrypt(CookieValuePrefix::create($key, app('encrypter')->getKey()).$value, false);
    696|         })->merge($this->unencryptedCookies)->all();
    697|     }
    698| 
    699|     /**
```