### PR TITLE
Fix withoutMiddleware docblock

### DIFF
--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -60,7 +60,7 @@ trait MakesHttpRequests
     /**
      * Disable middleware for the test.
      *
-     * @param  null  $middleware
+     * @param  class-string[]|class-string|null  $middleware
      * @return $this
      */
     public function withoutMiddleware($middleware = null)


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

PHPStan complains when an argument other than `null` is provided to the `withoutMiddleware([Foobar::class]);` method.