### PR TITLE
[7.x] Drop old PHP and Laravel versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,31 +16,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4, '8.0', 8.1, 8.2]
-        laravel: [7, 8, 9, 10]
-        exclude:
-          - php: 7.2
-            laravel: 8
-          - php: 7.2
-            laravel: 9
-          - php: 7.2
-            laravel: 10
-          - php: 7.3
-            laravel: 9
-          - php: 7.3
-            laravel: 10
-          - php: 7.4
-            laravel: 9
-          - php: 7.4
-            laravel: 10
-          - php: '8.0'
-            laravel: 10
-          - php: 8.1
-            laravel: 7
-          - php: 8.2
-            laravel: 7
-          - php: 8.2
-            laravel: 8
+        php: [8.1, 8.2]
+        laravel: [10]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -10,24 +10,23 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^8.1",
         "ext-dom": "*",
-        "ext-json": "*",
-        "illuminate/contracts": "^7.0|^8.0|^9.0|^10.0",
-        "illuminate/database": "^7.0|^8.0|^9.0|^10.0",
-        "illuminate/http": "^7.0|^8.0|^9.0|^10.0",
-        "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
-        "illuminate/testing": "^7.0|^8.0|^9.0|^10.0",
+        "illuminate/contracts": "^10.0",
+        "illuminate/database": "^10.0",
+        "illuminate/http": "^10.0",
+        "illuminate/support": "^10.0",
+        "illuminate/testing": "^10.0",
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^8.5|^9.0",
-        "symfony/console": "^5.0|^6.0",
-        "symfony/css-selector": "^5.0|^6.0",
-        "symfony/dom-crawler": "^5.0|^6.0",
-        "symfony/http-foundation": "^5.0|^6.0",
-        "symfony/http-kernel": "^5.0|^6.0"
+        "phpunit/phpunit": "^9.0",
+        "symfony/console": "^6.2",
+        "symfony/css-selector": "^6.2",
+        "symfony/dom-crawler": "^6.2",
+        "symfony/http-foundation": "^6.2",
+        "symfony/http-kernel": "^6.2"
     },
     "require-dev": {
-        "laravel/framework": "^7.0|^8.0|^9.0|^10.0"
+        "laravel/framework": "^10.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Drops Laravel below v10 and PHP below v8.1 to prepare for PHPUnit v10 support.