### PR TITLE
[develop] Removes usage of `Tests\CreatesApplication`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ use Laravel\BrowserKitTesting\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    use CreatesApplication;
-
     public $baseUrl = 'http://localhost';
 
     // ...

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -2,7 +2,9 @@
 
 namespace Laravel\BrowserKitTesting;
 
+use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -12,6 +14,7 @@ use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Support\Facades\Facade;
 use Mockery;
 use PHPUnit\Framework\TestCase as BaseTestCase;
+use RuntimeException;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -55,11 +58,22 @@ abstract class TestCase extends BaseTestCase
     /**
      * Creates the application.
      *
-     * Needs to be implemented by subclasses.
-     *
-     * @return \Symfony\Component\HttpKernel\HttpKernelInterface
+     * @return \Illuminate\Foundation\Application
      */
-    abstract public function createApplication();
+    public function createApplication()
+    {
+        if (method_exists(Application::class, 'inferBaseDirectory')) {
+            $app = require Application::inferBaseDirectory().'/bootstrap/app.php';
+
+            $app->make(Kernel::class)->bootstrap();
+
+            return $app;
+        }
+
+        throw new RuntimeException(
+            'Unable to guess application base directory. Please use the [Tests\CreatesApplication] trait.',
+        );
+    }
 
     /**
      * Setup the test environment.


### PR DESCRIPTION
This pull request applies the necessary changes on this package on what concerns the removal of the `Tests\CreatesApplication` trait. This change follows the pull request found at: https://github.com/laravel/laravel/pull/6310.