### PR TITLE
[7.x] Fixes `inferBasePath` method name

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -62,8 +62,8 @@ abstract class TestCase extends BaseTestCase
      */
     public function createApplication()
     {
-        if (method_exists(Application::class, 'inferBaseDirectory')) {
-            $app = require Application::inferBaseDirectory().'/bootstrap/app.php';
+        if (method_exists(Application::class, 'inferBasePath')) {
+            $app = require Application::inferBasePath().'/bootstrap/app.php';
 
             $app->make(Kernel::class)->bootstrap();
 


### PR DESCRIPTION
Updates method name after this: https://github.com/laravel/framework/commit/808debb3687604a92f1a9cf7bfab248a6259e3cc.